### PR TITLE
v3.2.0 update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18)
-project(sfun VERSION 3.1.1 DESCRIPTION "stuff from unnamed namespaces - a c++17 helper library")
+project(sfun VERSION 3.2.0 DESCRIPTION "stuff from unnamed namespaces - a c++17 helper library")
 include(GNUInstallDirs)
 include(external/seal_lake)
 

--- a/include/sfun/path.h
+++ b/include/sfun/path.h
@@ -1,0 +1,31 @@
+#ifndef SFUN_PATH_H
+#define SFUN_PATH_H
+
+#include "winconv.h"
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+namespace sfun {
+
+inline std::filesystem::path makePath(std::string_view str)
+{
+#ifdef _WIN32
+    return toUtf16(str);
+#else
+    return str;
+#endif
+}
+
+inline std::string pathString(const std::filesystem::path& path)
+{
+#ifdef _WIN32
+    return toUtf8(path.wstring());
+#else
+    return path.string();
+#endif
+}
+
+} //namespace sfun
+
+#endif //SFUN_PATH_H

--- a/include/sfun/utility.h
+++ b/include/sfun/utility.h
@@ -16,15 +16,18 @@ namespace sfun {
 template<typename T>
 inline constexpr auto dependent_false = false;
 
+using ssize_t = std::ptrdiff_t;
+using index_t = std::ptrdiff_t;
+
 template<class C>
-constexpr auto ssize(const C& c) -> std::common_type_t<std::ptrdiff_t, std::make_signed_t<decltype(c.size())>>
+constexpr auto ssize(const C& c) -> std::common_type_t<ssize_t, std::make_signed_t<decltype(c.size())>>
 {
-    using R = std::common_type_t<std::ptrdiff_t, std::make_signed_t<decltype(c.size())>>;
+    using R = std::common_type_t<ssize_t, std::make_signed_t<decltype(c.size())>>;
     return static_cast<R>(c.size());
 }
 
 template<class T, std::ptrdiff_t N>
-constexpr std::ptrdiff_t ssize(const T (&)[N]) noexcept
+constexpr ssize_t ssize(const T (&)[N]) noexcept
 {
     return N;
 }

--- a/include/sfun/winconv.h
+++ b/include/sfun/winconv.h
@@ -1,0 +1,38 @@
+#ifndef SFUN_WINCONV_H
+#define SFUN_WINCONV_H
+
+#ifdef _WIN32
+#include <windows.h>
+#include <string>
+
+namespace sfun {
+
+inline std::string toUtf8(std::wstring_view utf16String)
+{
+    int count = WideCharToMultiByte(
+            CP_UTF8,
+            0,
+            utf16String.data(),
+            static_cast<int>(utf16String.size()),
+            nullptr,
+            0,
+            nullptr,
+            nullptr);
+    auto utf8String = std::string(count, 0);
+    WideCharToMultiByte(CP_UTF8, 0, utf16String.data(), -1, &utf8String[0], count, nullptr, nullptr);
+    return utf8String;
+}
+
+inline std::wstring toUtf16(std::string_view utf8String)
+{
+    int count = MultiByteToWideChar(CP_UTF8, 0, utf8String.data(), static_cast<int>(utf8String.size()), nullptr, 0);
+    auto utf16String = std::wstring(count, 0);
+    MultiByteToWideChar(CP_UTF8, 0, utf8String.data(), static_cast<int>(utf8String.size()), &utf16String[0], count);
+    return utf16String;
+}
+
+} //namespace sfun
+
+#endif
+
+#endif //SFUN_WINCONV_H


### PR DESCRIPTION
-added the path.h header containing utilities to use std::filesystem::path with utf8 values in a cross-platform way;
-added ssize_t and index_t aliases to ptrdiff_t in utility.h;
-added the winconv.h header with utf8 to utf16 conversion utils that use the Windows API;